### PR TITLE
docs(rules): strengthen untracked file scope in atomic commit analysis

### DIFF
--- a/git-atomic-commit-construction-rules.md
+++ b/git-atomic-commit-construction-rules.md
@@ -21,12 +21,19 @@ protocols defined in [git-operation-rules.md](./git-operation-rules.md).
 Before staging any files, the agent MUST perform a dependency analysis of all
 modifications.
 
+- **Complete Scope (Critical)**: The analysis MUST cover ALL three change
+  categories — **staged**, **unstaged**, AND **untracked** — as a single
+  unified inventory from the very first step. Untracked files are first-class
+  members of the change scope, not a secondary check. Failing to include
+  untracked files in the initial analysis leads to incomplete commit plans and
+  files discovered only after execution.
 - **Shared Identifiers**: Group changes that modify the same functions,
   classes, or constants across different files.
 - **Cross-File References**: If file A depends on a change in file B (e.g., an
   import or a link), they MUST be part of the same atomic commit.
-- **Untracked File Discovery**: The agent MUST explicitly check for untracked
-  files (`git status`).
+- **Untracked File Discovery**: The agent MUST include untracked files
+  reported by `git status` in the initial change inventory. They MUST appear
+  in the same file table and grouping analysis as staged and unstaged changes.
 - **Implicit Tracking**: Any untracked file not excluded by `.gitignore` is a
   candidate for version control to ensure project completeness.
 - **Mandatory Confirmation**: The agent MUST NOT stage or commit untracked


### PR DESCRIPTION
Add 'Complete Scope (Critical)' mandate requiring all three change categories (staged, unstaged, untracked) to be analyzed as a unified inventory from the first step. Reword 'Untracked File Discovery' to explicitly require untracked files in the same file table and grouping analysis as staged and unstaged changes. These changes prevent incomplete commit plans caused by late discovery of untracked files.

## Summary by Sourcery

Strengthen the atomic commit construction rules to treat untracked files as first-class participants in dependency analysis from the outset.

Documentation:
- Clarify that dependency analysis must consider staged, unstaged, and untracked changes as a unified scope from the first step.
- Update the untracked file discovery rule to require untracked files be included in the same file inventory and grouping analysis as tracked changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated commit construction rules to clarify that untracked files are included as first-class citizens alongside staged and unstaged changes in the dependency analysis process, ensuring they appear in the same change inventory and grouping analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->